### PR TITLE
Can't edit existing salutations

### DIFF
--- a/salutations.php
+++ b/salutations.php
@@ -185,10 +185,25 @@ function salutations_civicrm_buildForm($formName, &$form) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_validateForm/
  */
 function salutations_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
-  if($formName == 'CRM_Contact_Form_CustomData') {
+  if ($formName == 'CRM_Contact_Form_CustomData') {
     $contact_id = $form->get('entityID');
-    $salutation_type = "custom_" . civicrm_api3('CustomField', 'getvalue', ['return' => "id",'name' => "salutation_type",]);
-    $existing_salutations = civicrm_api3('CustomValue', 'get', ['sequential' => 1,'return' => ["$salutation_type"],'entity_id' => $contact_id,]);
+    $salutation_type = "custom_" . civicrm_api3('CustomField', 'getvalue', ['return' => "id",
+              'name' => "salutation_type",]);
+    // Make sure this is a new field; updates are allowed to update themselves.
+    // Array keys in $fields look like 'custom_6_567', where '567' is the custom
+    // value ID, which unfortunately there's no easier way to get.
+    $fieldsKeys = array_keys($fields);
+    $customValueKey = preg_grep('/' . $salutation_type . '_/', $fieldsKeys);
+    preg_match('/' . $salutation_type . '_((\d)+)/', array_pop($customValueKey), $matches);
+    $customValueId = $matches[1];
+
+    $existing_salutations = civicrm_api3('CustomValue', 'get', ['sequential' => 1,
+      'return' => ["$salutation_type"], 'entity_id' => $contact_id,]);
+    // Remove the current record's ID from $existingSalutations
+    if ($existing_salutations['values'][0][$customValueId]) {
+      unset($existing_salutations['values'][0][$customValueId]);
+      unset($existing_salutations['values'][0]['latest']);
+    }
     foreach($fields as $fieldKey => $fieldValue) {
       if (stristr($fieldKey, $salutation_type)) {
         if (in_array($fieldValue, $existing_salutations['values'][0])) {

--- a/salutations.php
+++ b/salutations.php
@@ -164,6 +164,8 @@ function salutations_civicrm_entityTypes(&$entityTypes) {
 function salutations_civicrm_buildForm($formName, &$form) {
   if ($formName == 'CRM_Contact_Form_CustomData') {
     CRM_Core_Resources::singleton()->addScriptFile('com.jlacey.salutations', 'js/salutations.js');
+    //Widen the Salutation drop-down.
+    CRM_Core_Resources::singleton()->addStyle('#select2-drop {width: 600px !important;}');
   }
   if ($formName == 'CRM_Contact_Form_Contact' ||
       $formName == 'CRM_Contact_Form_Inline_CommunicationPreferences') {


### PR DESCRIPTION
**Note: This includes PR #2 in it.**

The `validateForm` hook checks to see if a salutation of this type already exists.  However, if you edit an existing salutation without updating the type, it fails this validation - because, well, a salutation of this type DOES exist.  This PR removes the current record from the `$existing_salutations` array so we don't trigger validation against itself.  It also removes the `latest` value for the same reason.